### PR TITLE
Make logging optional

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -22,6 +22,7 @@ function Airbrake() {
   this.appVersion = null;
   this.timeout = 30 * 1000;
   this.developmentEnvironments = ['development', 'test'];
+  this.consoleLogError = false;
 
   this.protocol = 'http';
   this.serviceHost =  process.env.AIRBRAKE_SERVER || 'api.airbrake.io';
@@ -95,7 +96,7 @@ Airbrake.prototype.handleExceptions = function() {
 };
 
 Airbrake.prototype.log = function(str) {
-  console.error(str);
+  if(this.consoleLogError) console.error(str);
 };
 
 Airbrake.prototype.notify = function(err, cb) {


### PR DESCRIPTION
We use Winston to log our errors, we have added a custom transport on there to post the errors to Airbrake. In dev we don't want to log the error using winston and have airbrake log the error as well. So I added an option that is able to disable the logging on test/development.

At the moment it is set to false by default (don't log error).