### PR TITLE
add missing var

### DIFF
--- a/lib/airbrake.js
+++ b/lib/airbrake.js
@@ -260,7 +260,7 @@ Airbrake.prototype.addRequestVars = function(request, type, vars) {
   Object.keys(vars).forEach(function(key) {
     node = node || request.ele(type);
 
-    value = vars[key];
+    var value = vars[key];
     if ('string' !== typeof value) {
       value = util.inspect(value, { showHidden: true, depth: null });
     }
@@ -342,7 +342,7 @@ Airbrake.prototype.appendServerEnvironmentXml = function(notice) {
 
   serverEnvironment
       .ele('environment-name')
-      .txt(this.env)
+      .txt(this.env);
 
   if (this.appVersion) {
     serverEnvironment


### PR DESCRIPTION
missing `var` keyword throws error

```                                                     
ReferenceError: value is not defined                                                          
    at /Users/moogs/Development/app/node_modules/winston-airb
rake2/node_modules/airbrake/lib/airbrake.js:262:11                                            
    at Array.forEach (native)                                                                 
    at Airbrake.addRequestVars (/Users/moogs/Development/app/
node_modules/winston-airbrake2/node_modules/airbrake/lib/airbrake.js:259:21)                  
    at Airbrake.appendRequestXml (/Users/moogs/Development/ap
p/node_modules/winston-airbrake2/node_modules/airbrake/lib/airbrake.js:250:8)                 
    at Airbrake.notifyXml (/Users/moogs/Development/app/node_
modules/winston-airbrake2/node_modules/airbrake/lib/airbrake.js:181:8)                        
    at Airbrake.notify (/Users/moogs/Development/app/node_mod
ules/winston-airbrake2/node_modules/airbrake/lib/airbrake.js:109:19)                          
    at Airbrake.log (/Users/moogs/Development/app/node_module
s/winston-airbrake2/lib/transport.js:60:17)                                                   
    at emit (/Users/moogs/Development/app/node_modules/winsto
n/lib/winston/logger.js:186:17)                                                               
    at /Users/moogs/Development/app/node_modules/winston/node
_modules/async/lib/async.js:122:13                                                            
    at _each (/Users/moogs/Development/app/node_modules/winst
on/node_modules/async/lib/async.js:46:13)                                                     
^C                                                                                            
```